### PR TITLE
Add customization support for usernames

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
   - "iojs"
+  - "iojs-v1.8.1"
 
 before_install:
   - sudo apt-get update -qq

--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ as long as they're present in the channel mapping.
   {
     "nickname": "test",
     "server": "irc.bottest.org",
-    "swarmUsernameFormat": "Anonymous Cat $username", // $username is replaced with the IRC user's username before posting to Friends 
+    "swarmUsernameFormat": "Anonymous $username (IRC)", // $username is replaced with the IRC user's username before posting to Friends
+    "ircUsernameFormat": "<$username>",
     "autoSendCommands": [ // Commands that will be sent on connect
       ["PRIVMSG", "NickServ", "IDENTIFY password"],
       ["MODE", "test", "+x"],

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ as long as they're present in the channel mapping.
   {
     "nickname": "test",
     "server": "irc.bottest.org",
+    "swarmUsernameFormat": "Anonymous Cat $username", // $username is replaced with the IRC user's username before posting to Friends 
     "autoSendCommands": [ // Commands that will be sent on connect
       ["PRIVMSG", "NickServ", "IDENTIFY password"],
       ["MODE", "test", "+x"],

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -25,7 +25,9 @@ function Bot (db, options) {
   this.server = options.server
   this.nickname = options.nickname
   this.ircOptions = options.ircOptions
+
   this.swarmUsernameFormat = options.swarmUsernameFormat || 'Anonymous $username (IRC)'
+  this.ircUsernameFormat = options.ircUsernameFormat || '<$username>'
 
   this.channels = _.values(options.channelMapping)
 
@@ -127,12 +129,16 @@ Bot.prototype.checkDuplicate = function (message) {
   return true
 }
 
+Bot.prototype.ircUsername = function (username) {
+  return this.ircUsernameFormat.replace(/\$username/g, username)
+}
+
 Bot.prototype.sendToIRC = function (message) {
   if (this.checkDuplicate(message)) return
   var ircChannel = this.channelMapping[message.channel]
   logger.debug('Trying to send to IRC', ircChannel, message)
   if (ircChannel) {
-    var text = '<' + message.username + '> ' + this.parseText(message.text)
+    var text = this.ircUsername(message.username) + ' ' + this.parseText(message.text)
     logger.debug('Sending message to IRC', ircChannel, text)
     this.ircClient.say(ircChannel, text)
   }

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -11,7 +11,7 @@ var REQUIRED_FIELDS = ['server', 'nickname', 'channelMapping']
 
 /**
  * An IRC bot, works as a middleman for all communication
- * @param {object} options - server, nickname, channelMapping, outgoingToken, incomingURL
+ * @param {object} options
  */
 function Bot (db, options) {
   REQUIRED_FIELDS.forEach(function (field) {
@@ -25,6 +25,7 @@ function Bot (db, options) {
   this.server = options.server
   this.nickname = options.nickname
   this.ircOptions = options.ircOptions
+  this.swarmUsernameFormat = options.swarmUsernameFormat || 'Anonymous $username (IRC)'
 
   this.channels = _.values(options.channelMapping)
 
@@ -137,6 +138,10 @@ Bot.prototype.sendToIRC = function (message) {
   }
 }
 
+Bot.prototype.swarmUsername = function (username) {
+  return this.swarmUsernameFormat.replace(/\$username/g, username)
+}
+
 Bot.prototype.sendToSwarm = function (author, channel, text) {
   var swarmChannel = this.invertedMapping[channel]
   if (swarmChannel) {
@@ -148,7 +153,7 @@ Bot.prototype.sendToSwarm = function (author, channel, text) {
 
     var message = {
       text: text,
-      username: 'Anonymous ' + author,
+      username: this.swarmUsername(author),
       channel: swarmChannel,
       timestamp: Date.now()
     }

--- a/test/bot.test.js
+++ b/test/bot.test.js
@@ -79,6 +79,24 @@ describe('Bot', function () {
     ClientStub.prototype.say.should.have.been.calledWith('#irc', ircText)
   })
 
+  it('should format usernames before sending to irc', function () {
+    var oldFormat = this.bot.swarmUsernameFormat
+    this.bot.ircUsernameFormat = 'Cat $username'
+
+    var text = 'testmessage'
+    var message = {
+      channel: 'swarm',
+      username: 'testuser',
+      text: text
+    }
+    this.bot.lastSent = false
+    this.bot.sendToIRC(message)
+    var ircText = 'Cat testuser ' + text
+    ClientStub.prototype.say.should.have.been.calledWith('#irc', ircText)
+
+    this.bot.ircUsernameFormat = oldFormat
+  })
+
   it('should not send messages to irc if the channel isn\'t in the channel mapping',
   function () {
     this.bot.swarm.returnWrongStubInfo = true

--- a/test/bot.test.js
+++ b/test/bot.test.js
@@ -40,8 +40,24 @@ describe('Bot', function () {
     this.bot.sendToSwarm(message.username, '#irc', message.text)
     var calledMessage = this.bot.swarm.send.getCall(0).args[0]
     calledMessage.text.should.equal(message.text)
-    calledMessage.username.should.equal('Anonymous ' + message.username)
+    calledMessage.username.should.equal('Anonymous ' + message.username + ' (IRC)')
     calledMessage.channel.should.equal('swarm')
+  })
+
+  it('should format usernames before sending to swarm', function () {
+    var message = {
+      text: 'testmessage',
+      username: 'testuser'
+    }
+
+    var oldFormat = this.bot.swarmUsernameFormat
+    this.bot.swarmUsernameFormat = 'Crazy $username'
+
+    this.bot.sendToSwarm(message.username, '#irc', message.text)
+    var calledMessage = this.bot.swarm.send.getCall(0).args[0]
+    calledMessage.username.should.equal('Crazy ' + message.username)
+
+    this.bot.swarmUsernameFormat = oldFormat
   })
 
   it('should not send messages to swarm if the channel isn\'t in the channel mapping',


### PR DESCRIPTION
This makes it possible to customize usernames before they're posted to Friends and IRC.

`"swarmUsernameFormat": "cat $username (IRC)"` would for example yield (replaces $username):
![image](https://cloud.githubusercontent.com/assets/3536982/7482476/045295ee-f378-11e4-92a0-faaebbfd8013.png)

It might be overkill, but it'll probably make it easier in regards to the [discussion](https://github.com/moose-team/friends/issues/80#issuecomment-98413291) about how messages should be posted.
